### PR TITLE
Allow rotating token issuer

### DIFF
--- a/contracts/ToucanRegenBridge.sol
+++ b/contracts/ToucanRegenBridge.sol
@@ -15,7 +15,7 @@ import "./interfaces/INCTPool.sol";
  * See README file for more information about the functionality
  */
 contract ToucanRegenBridge is Ownable, Pausable {
-    IContractRegistry public toucanContractRegistry;
+    IContractRegistry public immutable toucanContractRegistry;
 
     /// @notice total amount of tokens burned and signalled for transfer
     uint256 public totalTransferred;


### PR DESCRIPTION
Presumably there can be different levels of security between the admin account of the bridge and the token issuer (admin account is secured by cold storage, should not be used often, whereas the token issuer is a hot wallet that needs to issue tokens every now and then) so this change makes it possible for the owner to rotate the token issuer in case the latter is compromised. This should also allow us to deploy initially without specifying a token issuer but only set the issuer once the Regen-> Polygon flow is developed. @ryanchristo @pheuberger let me know if this makes sense to you