### PR TITLE
ci: bump slither action and use workaround version

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -52,9 +52,9 @@ jobs:
         run: yarn build
 
       - name: Run Slither
-        uses: crytic/slither-action@v0.1.1
+        uses: crytic/slither-action@v0.2.0
         with:
           ignore-compile: true
           node-version: 16
           slither-config: ./slither.config.json
-          slither-version: v0.8.3
+          slither-version: dev-workaround-action-48-0.8.3


### PR DESCRIPTION
Ref: https://github.com/crytic/slither-action/issues/48

This pull request bumps the slither action version and uses a custom slither version to resolve the issue referenced above.