### PR TITLE
[BLU-3625] Added Copyright info in the head of sol files

### DIFF
--- a/contracts/ToucanRegenBridge.sol
+++ b/contracts/ToucanRegenBridge.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier:  GPL-3.0
+// SPDX-License-Identifier:  GPL-3.0-or-later
+// Copyright (C) 2023 Toucan Labs
 
 pragma solidity 0.8.14;
 

--- a/contracts/interfaces/INCTPool.sol
+++ b/contracts/interfaces/INCTPool.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier:  GPL-3.0
+// SPDX-License-Identifier:  GPL-3.0-or-later
+// Copyright (C) 2023 Toucan Labs
 
 pragma solidity 0.8.14;
 

--- a/contracts/interfaces/ITCO2.sol
+++ b/contracts/interfaces/ITCO2.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier:  GPL-3.0
+// SPDX-License-Identifier:  GPL-3.0-or-later
+// Copyright (C) 2023 Toucan Labs
 
 pragma solidity 0.8.14;
 


### PR DESCRIPTION
The head of *.sol files must have Copyright info to comply with GPL documentation