### PR TITLE
[BLU-3628] Simplify access management

### DIFF
--- a/contracts/ToucanRegenBridge.sol
+++ b/contracts/ToucanRegenBridge.sol
@@ -85,10 +85,19 @@ contract ToucanRegenBridge is Pausable, AccessControl {
     //      Constructor
     // ----------------------------------------
 
-    constructor(INCTPool nctPool_) {
+    constructor(
+        INCTPool nctPool_,
+        bytes32[] memory roles,
+        address[] memory accounts
+    ) {
+        require(accounts.length == roles.length, "accounts and roles must have same length");
         nctPool = nctPool_;
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(PAUSER_ROLE, msg.sender);
+        bool hasAdmin = false;
+        for (uint256 i = 0; i < accounts.length; ++i) {
+            _grantRole(roles[i], accounts[i]);
+            if (roles[i] == DEFAULT_ADMIN_ROLE) hasAdmin = true;
+        }
+        require(hasAdmin, "should have at least one admin role");
     }
 
     // ----------------------------------------

--- a/contracts/ToucanRegenBridge.sol
+++ b/contracts/ToucanRegenBridge.sol
@@ -3,7 +3,6 @@
 pragma solidity 0.8.14;
 
 import "@openzeppelin/contracts/security/Pausable.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
 import "./interfaces/ITCO2.sol";
@@ -14,7 +13,7 @@ import "./interfaces/INCTPool.sol";
  *
  * See README file for more information about the functionality
  */
-contract ToucanRegenBridge is Ownable, Pausable, AccessControl {
+contract ToucanRegenBridge is Pausable, AccessControl {
     // ----------------------------------------
     //      Roles
     // ----------------------------------------
@@ -90,9 +89,10 @@ contract ToucanRegenBridge is Ownable, Pausable, AccessControl {
     //      Constructor
     // ----------------------------------------
 
-    constructor(address tokenIssuer_, INCTPool nctPool_) Ownable() {
+    constructor(address tokenIssuer_, INCTPool nctPool_) {
         tokenIssuer = tokenIssuer_;
         nctPool = nctPool_;
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(PAUSER_ROLE, msg.sender);
         if (tokenIssuer_ != address(0)) {
             _grantRole(PAUSER_ROLE, tokenIssuer_);
@@ -117,7 +117,7 @@ contract ToucanRegenBridge is Ownable, Pausable, AccessControl {
      * token issuer.
      * @param newIssuer Token issuer to be set
      */
-    function setTokenIssuer(address newIssuer) external onlyOwner {
+    function setTokenIssuer(address newIssuer) external onlyRole(DEFAULT_ADMIN_ROLE) {
         address oldIssuer = tokenIssuer;
         require(oldIssuer != newIssuer, "already set");
 
@@ -125,11 +125,11 @@ contract ToucanRegenBridge is Ownable, Pausable, AccessControl {
         emit TokenIssuerUpdated(oldIssuer, newIssuer);
     }
 
-    function grantPauserRole(address newPauser) external onlyOwner {
+    function grantPauserRole(address newPauser) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _grantRole(PAUSER_ROLE, newPauser);
     }
 
-    function revokePauserRole(address pauser) external onlyOwner {
+    function revokePauserRole(address pauser) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _revokeRole(PAUSER_ROLE, pauser);
     }
 

--- a/contracts/ToucanRegenBridge.sol
+++ b/contracts/ToucanRegenBridge.sol
@@ -125,14 +125,6 @@ contract ToucanRegenBridge is Pausable, AccessControl {
         emit TokenIssuerUpdated(oldIssuer, newIssuer);
     }
 
-    function grantPauserRole(address newPauser) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        _grantRole(PAUSER_ROLE, newPauser);
-    }
-
-    function revokePauserRole(address pauser) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        _revokeRole(PAUSER_ROLE, pauser);
-    }
-
     /**
      * @dev bridge tokens to Regen Network.
      * Burns Toucan TCO2 compatible tokens and signals a bridge event.

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1,8 +1,8 @@
 const { ethers } = require("hardhat");
 
-async function deployBridge(deployer, nctPool) {
+async function deployBridge(deployer, nctPool, accounts, roles) {
 	const Bridge = await ethers.getContractFactory("ToucanRegenBridge");
-	const bridge = await Bridge.connect(deployer).deploy(nctPool);
+	const bridge = await Bridge.connect(deployer).deploy(nctPool, accounts, roles);
 
 	await bridge.deployed();
 	return bridge;

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1,8 +1,8 @@
 const { ethers } = require("hardhat");
 
-async function deployBridge(tokenIssuer, nctPool) {
+async function deployBridge(deployer, nctPool) {
 	const Bridge = await ethers.getContractFactory("ToucanRegenBridge");
-	const bridge = await Bridge.deploy(tokenIssuer, nctPool);
+	const bridge = await Bridge.connect(deployer).deploy(nctPool);
 
 	await bridge.deployed();
 	return bridge;

--- a/test/ToucanRegenBridge.js
+++ b/test/ToucanRegenBridge.js
@@ -4,8 +4,10 @@ const { ethers } = require("hardhat");
 
 const { deployBridge } = require("../lib/bridge");
 const { prepareToucanEnv } = require("../lib/toucan");
+const { utils } = require("ethers");
 
 const DEFAULT_ADMIN_ROLE = ethers.constants.HashZero;
+const PAUSER_ROLE = utils.id("PAUSER_ROLE");
 
 function toWei(quantity) {
 	return ethers.utils.parseEther(quantity.toString(10));
@@ -60,7 +62,7 @@ describe("Bridge contract", function () {
 	});
 
 	it("should pause only with pauser role", async function () {
-		await bridge.connect(admin).grantPauserRole(broker.address);
+		await bridge.connect(admin).grantRole(PAUSER_ROLE, broker.address);
 
 		await bridge.connect(broker).pause();
 		expect(await bridge.paused()).equal(true);
@@ -68,7 +70,7 @@ describe("Bridge contract", function () {
 		await bridge.connect(broker).unpause();
 		expect(await bridge.paused()).equal(false);
 
-		await bridge.connect(admin).revokePauserRole(broker.address);
+		await bridge.connect(admin).revokeRole(PAUSER_ROLE, broker.address);
 		await expect(bridge.connect(broker).pause()).to.be.revertedWith("caller does not have pauser role");
 	});
 

--- a/test/ToucanRegenBridge.js
+++ b/test/ToucanRegenBridge.js
@@ -41,9 +41,31 @@ describe("Bridge contract", function () {
 		[admin, tokenIssuer, broker] = await ethers.getSigners();
 
 		// Deploy ToucanRegenBridge
-		bridge = await deployBridge(admin, nctPool.address);
-		await bridge.connect(admin).grantRole(TOKEN_ISSUER_ROLE, tokenIssuer.address);
+		bridge = await deployBridge(
+			admin,
+			nctPool.address,
+			[DEFAULT_ADMIN_ROLE, PAUSER_ROLE, TOKEN_ISSUER_ROLE],
+			[admin.address, admin.address, tokenIssuer.address]
+		);
 		await tco2Factory.addToAllowedBridges(bridge.address);
+	});
+
+	it("should fail to deploy with no assigned admin", async function () {
+		await expect(deployBridge(admin, nctPool.address, [], [])).to.be.revertedWith(
+			"should have at least one admin role"
+		);
+	});
+
+	it("should deploy with assigned roles", async function () {
+		const bridge = await deployBridge(
+			admin,
+			nctPool.address,
+			[DEFAULT_ADMIN_ROLE, PAUSER_ROLE, TOKEN_ISSUER_ROLE],
+			[admin.address, admin.address, tokenIssuer.address]
+		);
+		expect(await bridge.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be.true;
+		expect(await bridge.hasRole(PAUSER_ROLE, admin.address)).to.be.true;
+		expect(await bridge.hasRole(TOKEN_ISSUER_ROLE, tokenIssuer.address)).to.be.true;
 	});
 
 	it("Should set the right default admin and initial parameters", async function () {

--- a/test/ToucanRegenBridge.js
+++ b/test/ToucanRegenBridge.js
@@ -5,6 +5,8 @@ const { ethers } = require("hardhat");
 const { deployBridge } = require("../lib/bridge");
 const { prepareToucanEnv } = require("../lib/toucan");
 
+const DEFAULT_ADMIN_ROLE = ethers.constants.HashZero;
+
 function toWei(quantity) {
 	return ethers.utils.parseEther(quantity.toString(10));
 }
@@ -40,8 +42,9 @@ describe("Bridge contract", function () {
 		await tco2Factory.addToAllowedBridges(bridge.address);
 	});
 
-	it("Should set the right owner and initial parameters", async function () {
-		expect(await bridge.owner()).to.equal(admin.address);
+	it("Should set the right default admin and initial parameters", async function () {
+		const isAdmin = await bridge.hasRole(DEFAULT_ADMIN_ROLE, admin.address);
+		expect(isAdmin).to.be.true;
 		expect(await bridge.totalTransferred()).to.equal(0);
 	});
 


### PR DESCRIPTION
- removed the `Ownable` inheritance in favor of using the `DEFAULT_ADMIN_ROLE` in `AccessControl`
- assigned the `DEFAULT_ADMIN_ROLE` to the deployer in the constructor using `_grantRole` as `_setupRole` is deprecated
- removed custom role management in favor of `AccessControl` based roles (for pauser and token issuer)

