### PR TITLE
Redeploy mumbai bridge for a clean start

### DIFF
--- a/deployments/mumbai/ToucanRegenBridge.json
+++ b/deployments/mumbai/ToucanRegenBridge.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x4aaDDB511dAc5A7faFc9F9D336Ad79c2c890fA56",
+  "address": "0x6AE2341B158909F940EB1704393e97901C005861",
   "abi": [
     {
       "inputs": [


### PR DESCRIPTION
During testing, credits were bridged to different credit classes which messed up accounting state variables.  So make a fresh start with this staging deployment.